### PR TITLE
Redshift views support

### DIFF
--- a/sqeleton/databases/redshift.py
+++ b/sqeleton/databases/redshift.py
@@ -130,6 +130,8 @@ class Redshift(PostgreSQL):
             if len(type_info) > 1:
                 if base_type == 'numeric':
                     precision, scale = type_info[1][:-1].split(',')
+                    precision = int(precision)
+                    scale = int(scale)
                 
             out = [col_name, base_type, None, precision, scale]
             output[col_name] = tuple(out)
@@ -140,10 +142,7 @@ class Redshift(PostgreSQL):
         try:
             return super().query_table_schema(path)
         except RuntimeError:
-            try:
-                return self.query_external_table_schema(path)
-            except RuntimeError:
-                return self.query_pg_get_cols() 
+            return self.query_external_table_schema(path)
 
     def _normalize_table_path(self, path: DbPath) -> DbPath:
         if len(path) == 1:

--- a/sqeleton/databases/redshift.py
+++ b/sqeleton/databases/redshift.py
@@ -142,7 +142,10 @@ class Redshift(PostgreSQL):
         try:
             return super().query_table_schema(path)
         except RuntimeError:
-            return self.query_external_table_schema(path)
+            try:
+                return self.query_external_table_schema(path)	
+            except RuntimeError:	
+                return self.query_pg_get_cols() 
 
     def _normalize_table_path(self, path: DbPath) -> DbPath:
         if len(path) == 1:


### PR DESCRIPTION
Added support for querying view schemas. 

If a table is not found in either `information_schema.columns`, nor in `svv_external_columns`, we now use `pg_get_cols` to look up column type information in case the "table" is actually a view.