### PR TITLE
Added missing DATE type to Oracle

### DIFF
--- a/sqeleton/databases/oracle.py
+++ b/sqeleton/databases/oracle.py
@@ -92,6 +92,7 @@ class Dialect(BaseDialect, Mixin_Schema, Mixin_OptimizerHints):
         "NCHAR": Text,
         "NVARCHAR2": Text,
         "VARCHAR2": Text,
+        "DATE": Timestamp,
     }
     ROUNDS_ON_PREC_LOSS = True
     PLACEHOLDER_TABLE = "DUAL"


### PR DESCRIPTION
Without this, DATE columns get cast to strings instead of timestamps, which causes false positives.