### PR TITLE
Oracle ROWID support

### DIFF
--- a/sqeleton/databases/oracle.py
+++ b/sqeleton/databases/oracle.py
@@ -194,6 +194,19 @@ class Oracle(ThreadedDatabase):
         except self._oracle.DatabaseError as e:
             raise QueryError(e)
 
+    def query_table_schema(self, path: DbPath) -> Dict[str, tuple]:
+        rows = self.query(self.select_table_schema(path), list)
+        if not rows:
+            raise RuntimeError(f"{self.name}: Table '{'.'.join(path)}' does not exist, or has no columns")
+
+        d = {r[0]: r for r in rows}
+        
+        # all oracle tables have a ROWID pseudocolumn
+        d['ROWID'] = ('ROWID', 'VARCHAR2', 6, None, None)
+
+        assert (len(d)-1) == len(rows)
+        return d
+
     def select_table_schema(self, path: DbPath) -> str:
         schema, name = self._normalize_table_path(path)
 

--- a/sqeleton/utils.py
+++ b/sqeleton/utils.py
@@ -139,7 +139,7 @@ class CaseSensitiveDict(dict, CaseAwareMapping):
 
 # -- Alphanumerics --
 
-alphanums = " -" + string.digits + string.ascii_uppercase + "_" + string.ascii_lowercase
+alphanums = " +-./" + string.digits + string.ascii_uppercase + "_" + string.ascii_lowercase
 
 
 class ArithString:


### PR DESCRIPTION
All Oracle tables have a ROWID [pseudocolumn](https://docs.oracle.com/database/121/SQLRF/pseudocolumns008.htm#SQLRF00254). 

If a table has no primary key defined in the DDL, we can use `ROWID` as the key_column. This is useful for diffing Oracle tables with no primary key that have been replicated by Fivetran, since Fivetran creates a `_fivetran_id` column in the destination table with `ROWID` data.

**New Alphanumerics**
- `+./`
- The `ROWID` column may contain any of the above characters in addition to the base alphanumerics