### PR TITLE
Add further handling of key auth in Snowflake

### DIFF
--- a/sqeleton/databases/snowflake.py
+++ b/sqeleton/databases/snowflake.py
@@ -162,7 +162,6 @@ class Snowflake(Database):
         logging.getLogger("snowflake.connector.network").disabled = True
 
         assert '"' not in schema, "Schema name should not contain quotes!"
-        print(kw)
         # If a private key is used, read it from the specified path and pass it as "private_key" to the connector.
         if "key" in kw:
             if "password" in kw:

--- a/sqeleton/databases/snowflake.py
+++ b/sqeleton/databases/snowflake.py
@@ -163,7 +163,7 @@ class Snowflake(Database):
 
         assert '"' not in schema, "Schema name should not contain quotes!"
         # If a private key is used, read it from the specified path and pass it as "private_key" to the connector.
-        if "key" in kw:
+        if "key" in kw or "key_path" in kw:
             if "password" in kw:
                 raise ConnectError("Cannot use password and key at the same time")
             kw["private_key"] = self._get_private_key(kw, serialization, default_backend)

--- a/sqeleton/databases/snowflake.py
+++ b/sqeleton/databases/snowflake.py
@@ -162,6 +162,7 @@ class Snowflake(Database):
         logging.getLogger("snowflake.connector.network").disabled = True
 
         assert '"' not in schema, "Schema name should not contain quotes!"
+        print(kw)
         # If a private key is used, read it from the specified path and pass it as "private_key" to the connector.
         if "key" in kw:
             if "password" in kw:
@@ -174,21 +175,21 @@ class Snowflake(Database):
     @staticmethod
     def _get_private_key(kw, serialization, default_backend):
         """Get Snowflake private key by path, from a Base64 encoded DER bytestring or None."""
-        if kw.get("private_key") and kw.get("private_key_path"):
+        if kw.get("key") and kw.get("key_path"):
             raise Exception("Cannot specify both `private_key` and `private_key_path`")
-        if kw.get("private_key_passphrase"):
-            encoded_passphrase = kw.get("private_key_passphrase").encode()
+        if kw.get("key_passphrase"):
+            encoded_passphrase = kw.get("key_passphrase").encode()
         else:
             encoded_passphrase = None
 
-        if kw.get("private_key"):
+        if kw.get("key"):
             p_key = serialization.load_der_private_key(
-                base64.b64decode(kw.get("private_key")),
+                base64.b64decode(kw.get("key")),
                 password=encoded_passphrase,
                 backend=default_backend(),
             )
-        elif kw.get("private_key_path"):
-            with open(kw.get("private_key_path"), "rb") as key:
+        elif kw.get("key_path"):
+            with open(kw.get("key_path"), "rb") as key:
                 p_key = serialization.load_pem_private_key(
                     key.read(), password=encoded_passphrase, backend=default_backend()
                 )


### PR DESCRIPTION
Relating to @dlawin ask to move code from [this PR](https://github.com/datafold/data-diff/pull/450) downstream as to increase DRY-ness

Using `poetry run python3 -m data_diff --dbt` with a password (incorrect due to our org's restriction on un/pw) from a `profile.yml` results in:
```bash
[13:26:08] ERROR - 250001 (08001): Failed to connect to DB: xxx.us-east-1.snowflakecomputing.com:443. Incorrect username or password was specified.
```

running the same command while specifying a `private_key_path` and `private_key_passphrase` results in 
```bash
[13:18:29] ERROR - Bad decrypt. Incorrect password?
```
or, with correct key auth:
```bash
[15:07:12] ERROR - 002003 (02000): SQL compilation error:
Database 'XXX' does not exist or not authorized.
```
indicating successful authentication