### PR TITLE
Support smallint for Redshift

### DIFF
--- a/sqeleton/databases/postgresql.py
+++ b/sqeleton/databases/postgresql.py
@@ -67,6 +67,7 @@ class PostgresqlDialect(BaseDialect, Mixin_Schema):
         "double precision": Float,
         "real": Float,
         "decimal": Decimal,
+        "smallint": Integer,
         "integer": Integer,
         "numeric": Decimal,
         "bigint": Integer,


### PR DESCRIPTION
Read this ticket for more info https://github.com/datafold/data-diff/issues/475

TLDR
Used to have the following error when comparing MySQL <> Redshift
```sh
  File "/Users/mattdelacour/Documents/src/coinlist/pipo/.venv/lib/python3.10/site-packages/data_diff/hashdiff_tables.py", line 99, in _validate_and_adjust_columns
    raise TypeError(f"Incompatible types for column '{c1}':  {col1} <-> {col2}")
TypeError: Incompatible types for column 'converted_from_additional_allocation':  Integer(precision=0, python_type=<class 'int'>) <-> UnknownColType(text='smallint')
```

And my full python script works once I add the support for smallint for Redshift
![image](https://user-images.githubusercontent.com/18557047/229858271-55dc5094-1b6f-4fcc-9bc9-6c295a08d4b7.png)
